### PR TITLE
The JSON method should be awaited

### DIFF
--- a/src/api/util.js
+++ b/src/api/util.js
@@ -56,7 +56,7 @@ export async function blockfrostRequest(endpoint, headers, body) {
       method: body ? 'POST' : 'GET',
       body,
     });
-    result = rawResult.json();
+    result = await rawResult.json();
   }
 
   return result;


### PR DESCRIPTION
I made a mistake in my last PR, https://github.com/Berry-Pool/nami-wallet/pull/129 I didn’t await for the .json() call on the response.