### PR TITLE
Added check on empty assetName

### DIFF
--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -1297,6 +1297,7 @@ export const initHW = async ({ device, id }) => {
  * @param {string} assetName utf8 encoded
  */
 export const getAdaHandle = async (assetName) => {
+  if (!assetName || assetName.length == 0) return null;
   const network = await getNetwork();
   const assetNameHex = Buffer.from(assetName).toString('hex');
   const policy = ADA_HANDLE[network.id];

--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -1297,9 +1297,9 @@ export const initHW = async ({ device, id }) => {
  * @param {string} assetName utf8 encoded
  */
 export const getAdaHandle = async (assetName) => {
-  if (!assetName || assetName.length == 0) return null;
   const network = await getNetwork();
   const assetNameHex = Buffer.from(assetName).toString('hex');
+  if (!assetNameHex || assetNameHex.length == 0) return null;
   const policy = ADA_HANDLE[network.id];
   const asset = policy + assetNameHex;
   const resolvedAddress = await blockfrostRequest(`/assets/${asset}/addresses`);


### PR DESCRIPTION
I had attempted to send an NFT from my wallet using the recipient wallet's $handle. Instead of going to the wallet that owns the $handle, the NFT was sent to the adahandle team's wallet that holds a special "empty" handle ([link](https://cardanoscan.io/token/f0ff48bbb7bbe9d59a40f1ce90e9e9d0ff5002ec48f232b49ca0fb9a?address=addr1qye59j5vquaprdmxf0gs2y3n20necqg3dnzxty23x07u7awkchm0w43pg2uczh4vcvdr59teny2996rq4tmq2umjyqvqlhm7d2)).

It appears as if just the adahandle policy is sent to the blockfrost api, it returns the address of the "empty" handle. For example,
```javascript
blockfrostRequest(`/assets/${policy}/addresses`) // only sending policy
>>> 'addr1qye59j5vquaprdmxf0gs2y3n20necqg3dnzxty23x07u7awkchm0w43pg2uczh4vcvdr59teny2996rq4tmq2umjyqvqlhm7d2'
```

This suggests that `assetName` was an empty string and `asset = policy + assetNameHex;` is equivalent to `asset = policy`. 

I couldn't figure out how an empty string got passed to `getAdaHandle` from reading through `src/ui/app/pages/send.jsx`... But I figured checking if the `assetName` was empty would at least prevent something like what happened to me to happen again.

Additional notes:
* Version 3.0.0, Brave Version 1.26.74 Chromium: 91.0.4472.124 (Official Build) (64-bit), Ubuntu 20.04
* I've been chatting with Calvin on the Handle team. I should be receiving my misplaced NFT soon :smile: 
* I did not test the change