### PR TITLE
Add off method

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,4 +14,5 @@ module.exports = {
   },
   transformIgnorePatterns: [`/node_modules/(?!crypto-random-string)`],
   setupFilesAfterEnv: ['./jest.setup.js'],
+  testEnvironment: 'jsdom'
 };

--- a/src/api/messaging.js
+++ b/src/api/messaging.js
@@ -171,7 +171,7 @@ export const Messaging = {
       // protect background by not allowing not whitelisted
       if (!whitelisted || whitelisted.error) return;
 
-      const event = new CustomEvent(TARGET + response.event, {
+      const event = new CustomEvent(`${TARGET}${response.event}`, {
         detail: response.data,
       });
 

--- a/src/api/webpage/eventRegistring.js
+++ b/src/api/webpage/eventRegistring.js
@@ -15,6 +15,8 @@ export const on = (eventName, callback) => {
   ];
 
   window.addEventListener(`${TARGET}${eventName}`, handler);
+
+  return { remove: () => off(eventName, callback) };
 };
 
 /**

--- a/src/api/webpage/eventRegistring.js
+++ b/src/api/webpage/eventRegistring.js
@@ -1,0 +1,43 @@
+import { TARGET } from '../../config/config';
+
+/**
+ * @param {string} eventName 
+ * @param {Function} callback 
+ */
+export const on = (eventName, callback) => {
+  const handler = (event) => callback(event.detail);
+
+  const events = window.cardano._events[eventName] || []; 
+
+  window.cardano._events[eventName] = [
+    ...events,
+    [ callback, handler ],
+  ];
+
+  window.addEventListener(`${TARGET}${eventName}`, handler);
+};
+
+/**
+ * @param {string} eventName 
+ * @param {Function} callback 
+ */
+export const off = (eventName, callback) => {
+  const filterHandlersBy = (predicate) => (handlers) => handlers.filter(
+    ([ savedCallback ]) => predicate(savedCallback)
+  );
+
+  const filterByMatchingHandlers = filterHandlersBy((cb) => cb === callback);
+  const filterByNonMatchingHandlers = filterHandlersBy((cb) => cb !== callback);
+
+  const eventHandlers = window.cardano._events[eventName];
+
+  if (typeof eventHandlers !== 'undefined') {
+    const matchingHandlers = filterByMatchingHandlers(eventHandlers);
+
+    for (const [, handler] of matchingHandlers) {
+      window.removeEventListener(`${TARGET}${eventName}`, handler);
+    }
+
+    window.cardano._events[eventName] = filterByNonMatchingHandlers(eventHandlers);
+  }
+};

--- a/src/api/webpage/index.js
+++ b/src/api/webpage/index.js
@@ -1,4 +1,4 @@
-import { EVENT, METHOD, SENDER, TARGET } from '../../config/config';
+import { METHOD } from '../../config/config';
 import { Messaging } from '../messaging';
 
 export const getBalance = async () => {
@@ -76,32 +76,4 @@ export const submitTx = async (tx) => {
   return result.data;
 };
 
-export const on = (eventName, callback) => {
-  const fn = (e) => callback(e.detail);
-  Object.defineProperty(fn, 'name', { value: callback.name });
-  window.cardano._events[eventName] = [
-    ...(window.cardano._events[eventName] || []),
-    fn,
-  ];
-  window.addEventListener(
-    TARGET + eventName,
-    window.cardano._events[eventName][
-      window.cardano._events[eventName].length - 1
-    ]
-  );
-};
-
-export const removeListener = (eventName, callback) => {
-  const fn = window.cardano._events[eventName].find(
-    (f) => f.name == callback.name
-  );
-  if (!fn) return;
-  const index = window.cardano._events[eventName].indexOf(fn);
-  window.removeEventListener(
-    TARGET + eventName,
-    window.cardano._events[eventName][index]
-  );
-  window.cardano._events[eventName].splice(index, 1);
-  if (window.cardano._events[eventName].length <= 0)
-    delete window.cardano._events[eventName];
-};
+export { on, off } from './eventRegistring';

--- a/src/pages/Content/injected.js
+++ b/src/pages/Content/injected.js
@@ -8,7 +8,6 @@ import {
   getUtxos,
   isEnabled,
   on,
-  removeListener,
   signData,
   signTx,
   submitTx,

--- a/src/test/unit/api/webpage/eventRegistring.test.js
+++ b/src/test/unit/api/webpage/eventRegistring.test.js
@@ -66,8 +66,6 @@ describe('webpage/eventRegistring', () => {
     test('stops the given callback from being invoked when cleaned out', () => {
       off(mockEventType, mockCallback);
 
-      console.log(window.cardano._events);
-
       const event = makeEvent(mockEventType);
 
       window.dispatchEvent(event);

--- a/src/test/unit/api/webpage/eventRegistring.test.js
+++ b/src/test/unit/api/webpage/eventRegistring.test.js
@@ -1,0 +1,92 @@
+import { on, off } from '../../../../api/webpage/eventRegistring';
+import { TARGET } from '../../../../config/config';
+
+describe('webpage/eventRegistring', () => {
+  const makeEvent = (eventType, detail) => (new CustomEvent(`${TARGET}${eventType}`, { detail }));
+
+  describe('on', () => {
+
+    beforeEach(() => {
+      window.cardano = {
+        _events: {},
+      };
+    });
+
+    test('invokes the callback when a the target event is triggered', () => {
+      const eventType = 'mock-event';
+      const mockPayload = 'mock-payload';
+      const event = makeEvent(eventType, mockPayload);
+      const mockFn = jest.fn();
+
+      on(eventType, mockFn);
+
+      window.dispatchEvent(event);
+
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith(mockPayload);
+    });
+
+    test('does not invoke the callback when a different event is triggered', () => {
+      const mockFn = jest.fn();
+
+      on('event-A', mockFn);
+      
+      const mockPayload = 'mock-payload';
+      const event = makeEvent('event-B', mockPayload);
+
+      window.dispatchEvent(event);
+
+      expect(mockFn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('of', () => {
+    const mockEventType = 'mock-event';
+    const mockCallback = jest.fn();
+    const mockHandler = jest.fn().mockImplementation(() => mockCallback());
+     
+    beforeEach(() => {
+      jest.resetAllMocks();
+
+      window.cardano = {
+        _events: {
+          [mockEventType]: [[mockCallback, mockHandler]]
+        },
+      };
+    });
+
+    test('clean out matching callbacks fom the given event', () => {
+      off(mockEventType, mockCallback);
+
+      expect(window.cardano._events).toEqual({
+        [mockEventType]: []
+      })
+    });
+
+    test('stops the given callback from being invoked when cleaned out', () => {
+      off(mockEventType, mockCallback);
+
+      console.log(window.cardano._events);
+
+      const event = makeEvent(mockEventType);
+
+      window.dispatchEvent(event);
+
+      expect(mockCallback).not.toHaveBeenCalled()
+    });
+
+    test('does not stop other callbacks from being invoked after cleaned one out', () => {
+      const mockFn = jest.fn();
+
+      on('event-A', mockFn);
+
+      off('mockEventType', mockCallback);
+
+      const event = makeEvent('event-A');
+
+      window.dispatchEvent(event);
+
+      expect(mockFn).toHaveBeenCalledTimes(1)
+    });
+  });
+});

--- a/src/ui/app/components/transactionBuilder.jsx
+++ b/src/ui/app/components/transactionBuilder.jsx
@@ -26,7 +26,7 @@ import {
   UnorderedList,
   ListItem,
 } from '@chakra-ui/react';
-import { GoStop } from 'react-icons/Go';
+import { GoStop } from 'react-icons/go';
 // Assets
 import Berry from '../../../assets/img/berry.svg';
 import { ERROR } from '../../../config/config';


### PR DESCRIPTION
### Context

While following the thread https://github.com/cardano-foundation/CIPs/pull/151 I noticed some work was done very recently to support the on() proposal. I also notice a couple of issues with it, being 1) using `.name` of the callback to identify which to clear out and 2) Support to remove the callback was removed, while a lonely `removeListener` function was left

### Solution

- Added `off` method, based on `removeListener`
- Refactored the methods to use the callback reference, not the `.name`

**About using `.name`:**
This would only work when the given callback would not be an anonymous function.

Examples:

```js
function normalFn() {}
normalFn.name // normalFn

const arrow = () => {}
arrow.name // arrow

(() => {}).name // empty string
```

In order to identify which callback is which, the function reference works fine.

**About the `off` method:**
When firing it, all the matching callbacks assigned to a given event are removed and cleared from the window event listener. 

**Other notes**
- the import of 'react-icons/Go' was breaking my build due to the uppercase char
- tests were added to support the on/off methods
- I was not really sure about injecting the on/off to `window.cardano` right away, so I decided to return `{ remove: () => off() }` at the `on` method, which in the end is backwards compatable with the previous version
- I noticed that after the very latest push, the events were not working anymore. But with this PR they are. I am not sure if it is something I fixed, or it I was doing something wrong after I pulled.

