### PR TITLE
Added console log for signed tx.

### DIFF
--- a/src/api/messaging.js
+++ b/src/api/messaging.js
@@ -94,6 +94,9 @@ export const Messaging = {
   sendToContent: function ({ method, data }) {
     return new Promise((res, rej) => {
       const requestId = Math.random().toString(36).substr(2, 9);
+      if (method == METHOD.submitTx) {
+        console.log(data);
+      }
       window.addEventListener('message', function responseHandler(e) {
         const response = e.data;
         if (


### PR DESCRIPTION
Hey there!

I found myself having a hard time with Daedalus as my cardano-node while trying to get cardano-submit-api to work for Nami. I would highly appreciate if you would accept this PR which would simply display the signed tx as a cborHex string inside of the console log.

I will try and run cardano-submit-api with the cardano-node in the cli and see if I can get everything working. I would like to help in any way I can with some of this infrastructure to support the community.

Thanks.