### PR TITLE
Updating Message Signing Verify Documentation

### DIFF
--- a/MessageSigning.md
+++ b/MessageSigning.md
@@ -24,7 +24,23 @@ const verify = (address, payload, coseSign1Hex) => {
   const addressCose = S.Address.from_bytes(
     protectedHeaders.header(MS.Label.new_text('address')).as_bytes()
   );
-  const publicKeyCose = S.PublicKey.from_bytes(protectedHeaders.key_id());
+
+  // Commented out the below line in favor of CIP-30, only use if you are using the deprecated window.cardano.signedData(address, payload)
+  //const publicKeyCose = S.PublicKey.from_bytes(protectedHeaders.key_id());
+  const key = MS.COSEKey.from_bytes(
+          Buffer.from(coseKey, 'hex')
+      );
+  const publicKeyBytes = key
+      .header(
+          MS.Label.new_int(
+              MS.Int.new_negative(
+                  MS.BigNum.from_str('2')
+              )
+          )
+      )
+      .as_bytes();
+  const publicKeyCose =
+      APILoader.Cardano.PublicKey.from_bytes(publicKeyBytes);
 
   if (!verifyAddress(address, addressCose, publicKeyCose))
     throw new Error('Could not verify because of address mismatch');

--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -820,7 +820,7 @@ export const signDataCIP30 = async (
   protectedHeaders.set_algorithm_id(
     Loader.Message.Label.from_algorithm_id(Loader.Message.AlgorithmId.EdDSA)
   );
-  // protectedHeaders.set_key_id(publicKey.as_bytes());
+  // protectedHeaders.set_key_id(publicKey.as_bytes()); // Removed to adhere to CIP-30
   protectedHeaders.set_header(
     Loader.Message.Label.new_text('address'),
     Loader.Message.CBORValue.new_bytes(Buffer.from(address, 'hex'))


### PR DESCRIPTION
Currently, the MessageSigning.md file contains a signature verification implementation that does not work with CIP-30. This PR updates the documentation to include a solution that works for messages signed with signDataCIP30(...) internally.

This PR also updates the comments on the signDataCIP30 function to clarify why the change was made. Feedback on the comments are welcome.